### PR TITLE
Fix panic when StatefulSet is not found

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -35,8 +35,7 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	sts, err := r.fetchStatefulSet(ctx, req.NamespacedName)
 	if err != nil {
-		l.Error(err, "Unable to fetch StatefulSet")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if !sts.Resizing() || sts.Failed() {
 		return ctrl.Result{}, nil

--- a/controllers/statefulset.go
+++ b/controllers/statefulset.go
@@ -8,7 +8,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/vshn/statefulset-resize-controller/statefulset"
@@ -43,7 +42,7 @@ func (r StatefulSetReconciler) fetchStatefulSet(ctx context.Context, namespacedN
 	old := &appsv1.StatefulSet{}
 	err := r.Get(ctx, namespacedName, old)
 	if err != nil {
-		return nil, client.IgnoreNotFound(err)
+		return nil, err
 	}
 	sts, err := statefulset.NewEntity(old)
 	if err != nil {


### PR DESCRIPTION
## Summary

We will currently panic when the StatfulSet is not found.  Probably slipped through in later refactors.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
