### PR TITLE
Fix typos in configuration used to generate controller ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - serviceaccount
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -79,7 +79,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebinding
+  - rolebindings
   verbs:
   - create
   - delete

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -29,8 +29,8 @@ type StatefulSetReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebinding,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=serviceaccount,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is the main work loop, reacting to changes in statefulsets and initiating resizing of StatefulSets.
 func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary

We previously generated a ClusterRole referencing resources `serviceaccount` and `rolebinding`, which is incorrect as the plural form of resources must be used in ClusterRole and Role objects.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
