### PR TITLE
Use storage class requested by statefulset instead of the old PVC

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -1,4 +1,5 @@
-//+build integration
+//go:build integration
+// +build integration
 
 package controllers
 
@@ -20,6 +21,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -94,6 +96,7 @@ func TestController(t *testing.T) {
 			pvc := newSource(ns, "data-test-0", "1G",
 				func(pvc *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
 					pvc.Labels = sts.Spec.Selector.MatchLabels
+					pvc.Spec.StorageClassName = pointer.String("default-foobar") // Default storage class. Make sure it is not copied
 					return pvc
 				})
 			require.NoError(c.Create(ctx, pvc))

--- a/controllers/controller_util_test.go
+++ b/controllers/controller_util_test.go
@@ -1,4 +1,5 @@
-//+build integration
+//go:build integration
+// +build integration
 
 package controllers
 

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -40,7 +40,7 @@ func filterResizablePVCs(ctx context.Context, sts appsv1.StatefulSet, pvcs []cor
 		}
 		for _, tpl := range sts.Spec.VolumeClaimTemplates {
 			if isPVCTooSmall(ctx, p, tpl, sts.Name) {
-				res = append(res, pvc.NewEntity(p, tpl.Spec.Resources.Requests[corev1.ResourceStorage]))
+				res = append(res, pvc.NewEntity(p, tpl.Spec.Resources.Requests[corev1.ResourceStorage], tpl.Spec.StorageClassName))
 				break
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
+	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	sigs.k8s.io/controller-runtime v0.9.5
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20210713022429-8b55f85c90c3
 	sigs.k8s.io/controller-tools v0.6.2

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main


### PR DESCRIPTION
Until now we reused the storage class of the to be resized PVC. However that can be an issue if the requested or default storage class changed and the old storage class is not available anymore.

With this change we create new PVCs using the storage class (or the lack of it, i.e. default) of the statefulset.

## Summary



<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
